### PR TITLE
Move singleton to the initializer to be used by more things later

### DIFF
--- a/HamShield.cpp
+++ b/HamShield.cpp
@@ -11,6 +11,7 @@
 /* don't change this regulatory value, use dangerMode() and safeMode() instead */
 
 bool restrictions = true; 
+HamShield *HamShield::sHamShield = NULL;
 
 /* channel lookup tables */
 
@@ -47,6 +48,7 @@ volatile long bouncer = 0;
  */
 HamShield::HamShield() {
     devAddr = A1846S_DEV_ADDR_SENLOW;
+    sHamShield = this;
 }
 
 /** Specific address constructor.
@@ -1133,7 +1135,6 @@ uint32_t HamShield::findWhitespaceChannels(uint32_t buffer[],uint8_t buffsize, u
 void HamShield::buttonMode(uint8_t mode) { 
    pinMode(HAMSHIELD_AUX_BUTTON,INPUT);       // set the pin mode to input
    digitalWrite(HAMSHIELD_AUX_BUTTON,HIGH);   // turn on internal pull up
-   sHamShield = this; 
    if(mode == PTT_MODE) { attachInterrupt(HAMSHIELD_AUX_BUTTON, HamShield::isr_ptt, CHANGE); } 
    if(mode == RESET_MODE) { attachInterrupt(HAMSHIELD_AUX_BUTTON, HamShield::isr_reset, CHANGE); }
 }

--- a/HamShield.h
+++ b/HamShield.h
@@ -541,6 +541,8 @@ class HamShield {
         uint32_t GMRS[];
         uint32_t MURS[];
         uint32_t WX[];
+        
+    public:
         static HamShield *sHamShield; // HamShield singleton, used for ISRs mostly
          
 //          int8_t A1846S::readWord(uint8_t devAddr, uint8_t regAddr, uint16_t *data, uint16_t timeout);


### PR DESCRIPTION
The singleton and the initialization are moved up, so that the other ISRs for AFSK, etc. can see it. Also define the actual instance variable in the .cpp.
