### PR TITLE
Update HamShield.h to remove hyphen from define

### DIFF
--- a/HamShield.h
+++ b/HamShield.h
@@ -242,7 +242,7 @@
 
 
 #define ROBOT8BW 2
-#define SC2-180 55
+#define SC2180 55
 #define MARTIN1 44
 
 // RTTY Frequencies


### PR DESCRIPTION
Remove the hyphen in the define which causes the Arduino compiler to error. This define doesn't seem to be used anywhere.
