### PR TITLE
Fixed Frequency Display at startup in AX25Receive.ino

### DIFF
--- a/examples/AX25Receive/AX25Receive.ino
+++ b/examples/AX25Receive/AX25Receive.ino
@@ -47,6 +47,7 @@ void setup() {
   radio.frequency(145010);
   radio.setSQOff();
   Serial.println(F("Frequency"));
+  Serial.println(radio.getFrequency());
   delay(100);
   Serial.print(F("Squelch(H/L): "));
   Serial.print(radio.getSQHiThresh());


### PR DESCRIPTION
Added   Serial.println(radio.getFrequency()); to setup.  May have been
removed accidentaly
