### PR TITLE
Fix squelch threshold values for the AT1846S

### DIFF
--- a/src/HamShield.cpp
+++ b/src/HamShield.cpp
@@ -855,20 +855,20 @@ bool HamShield::getSQState(){
 void HamShield::setSQHiThresh(int16_t sq_hi_threshold){
 	// Sq detect high th, rssi_cmp will be 1 when rssi>th_h_sq, unit 1dB
 	uint16_t sq = 137 + sq_hi_threshold;
-	HSwriteWord(devAddr, A1846S_SQ_OPEN_THRESH_REG, sq);
+	HSwriteBitsW(devAddr, A1846S_SQ_OPEN_THRESH_REG, A1846S_SQ_OPEN_THRESH_BIT, A1846S_SQ_OPEN_THRESH_LENGTH, sq);
 } 
 int16_t HamShield::getSQHiThresh(){
-	HSreadWord(devAddr, A1846S_SQ_OPEN_THRESH_REG, radio_i2c_buf);
+	HSreadBitsW(devAddr, A1846S_SQ_OPEN_THRESH_REG, A1846S_SQ_OPEN_THRESH_BIT, A1846S_SQ_OPEN_THRESH_LENGTH, radio_i2c_buf);
 	
 	return radio_i2c_buf[0] - 137;
 }
 void HamShield::setSQLoThresh(int16_t sq_lo_threshold){
 	// Sq detect low th, rssi_cmp will be 0 when rssi<th_l_sq && time delay meet, unit 1 dB
 	uint16_t sq = 137 + sq_lo_threshold;
-	HSwriteWord(devAddr, A1846S_SQ_SHUT_THRESH_REG, sq);
+	HSwriteBitsW(devAddr, A1846S_SQ_SHUT_THRESH_REG, A1846S_SQ_SHUT_THRESH_BIT, A1846S_SQ_SHUT_THRESH_LENGTH, sq);
 }
 int16_t HamShield::getSQLoThresh(){
-	HSreadWord(devAddr, A1846S_SQ_SHUT_THRESH_REG, radio_i2c_buf);
+	HSreadBitsW(devAddr, A1846S_SQ_SHUT_THRESH_REG, A1846S_SQ_SHUT_THRESH_BIT, A1846S_SQ_SHUT_THRESH_LENGTH, radio_i2c_buf);
 	
 	return radio_i2c_buf[0] - 137;
 }

--- a/src/HamShield.h
+++ b/src/HamShield.h
@@ -42,7 +42,7 @@
 #define A1846S_FM_DEV_REG           0x43    // register holds fm deviation settings
 #define A1846S_RX_VOLUME_REG        0x44    // register holds RX volume settings
 #define A1846S_SUBAUDIO_REG         0x45    // sub audio register
-#define A1846S_SQ_OPEN_THRESH_REG   0x48    // see sq
+#define A1846S_SQ_OPEN_THRESH_REG   0x49    // see sq
 #define A1846S_SQ_SHUT_THRESH_REG   0x49    // see sq
 #define A1846S_CTCSS_FREQ_REG       0x4A    // ctcss_freq<15:0>
 #define A1846S_CDCSS_CODE_HI_REG    0x4B    // cdcss_code<23:16>
@@ -154,13 +154,13 @@
 #define A1846S_C_MODE_BIT          2  // c_mode<2:0>
 #define A1846S_C_MODE_LENGTH       3
 
-// Bitfields for A1846S_SQ_THRESH_REG
-#define A1846S_SQ_OPEN_THRESH_BIT     9  // sq open threshold <9:0>
-#define A1846S_SQ_OPEN_THRESH_LENGTH 10
+// Bitfields for A1846S_SQ_OPEN_THRESH_REG
+#define A1846S_SQ_OPEN_THRESH_BIT    13 // sq open threshold <13:7>
+#define A1846S_SQ_OPEN_THRESH_LENGTH 7
 
 // Bitfields for A1846S_SQ_SHUT_THRESH_REG
-#define A1846S_SQ_SHUT_THRESH_BIT     9  // sq shut threshold <9:0>
-#define A1846S_SQ_SHUT_THRESH_LENGTH 10
+#define A1846S_SQ_SHUT_THRESH_BIT    6  // sq shut threshold <6:0>
+#define A1846S_SQ_SHUT_THRESH_LENGTH 7
 
 // Bitfields for A1846S_SQ_OUT_SEL_REG
 #define A1846S_SQ_OUT_SEL_BIT      7  // sq_out_sel


### PR DESCRIPTION
Adjusts the SQ hi/lo threshold methods to write the the appropriate I2C registers for the Auctus AT1846S on the HamShield09.